### PR TITLE
Fix Google Maps reload crash on locale change

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -130,23 +130,29 @@ export default function Map({ objects, loading, language }: MapProps) {
     }
   }, [objects, loading])
 
-  // Очистка при размонтировании
+  // Очистка перед загрузкой нового языка и при размонтировании
   useEffect(() => {
     return () => {
+      // Удаляем маркеры
       markersRef.current.forEach(marker => marker.setMap(null))
+      markersRef.current = []
+
+      // Очищаем кластеризатор
       if (clustererRef.current) {
         clustererRef.current.clearMarkers()
+        clustererRef.current = null
       }
-      mapRef.current = null
-    }
-  }, [])
 
-  // Удаление предыдущих скриптов Google Maps при смене языка
-  useEffect(() => {
-    return () => {
+      // Сбрасываем ссылку на карту
+      mapRef.current = null
+
+      // Удаляем скрипты Google Maps и глобальный объект
       document
         .querySelectorAll('script[src*="maps.googleapis"]')
         .forEach(script => script.remove())
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).google
     }
   }, [currentLang])
 
@@ -174,7 +180,6 @@ export default function Map({ objects, loading, language }: MapProps) {
   return (
     <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
       <GoogleMap
-        key={currentLang}
         mapContainerStyle={mapContainerStyle}
         zoom={5}
         center={KAZAKHSTAN_CENTER}


### PR DESCRIPTION
## Summary
- reset Google Maps objects when language changes
- remove key prop and rely on loader for language updates

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: interactive ESLint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_68ad841af3ac833083ec3b3ed5259595