### PR TITLE
Handle cluster click to pan and zoom map

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -193,10 +193,28 @@ export default function Map({ objects, loading, language }: MapProps) {
         algorithm: new GridAlgorithm({
           gridSize: 60,
           maxDistance: 40000
-        })
+        }),
+        onClusterClick: (event, cluster, mapInstance) => {
+          event.stop()
+
+          const map = mapRef.current ?? mapInstance
+          const position = cluster?.position
+
+          if (!map || !position) {
+            return
+          }
+
+          map.panTo(position)
+
+          const currentZoom = map.getZoom() ?? 0
+          const maxZoom = 21
+          const targetZoom = Math.min(currentZoom + 2, maxZoom)
+
+          map.setZoom(targetZoom)
+        }
       })
     }
-  }, [objects, loading, language, mapReady]) 
+  }, [objects, loading, language, mapReady])
 
   if (!apiKey || !mapId) {
     return (


### PR DESCRIPTION
## Summary
- add a custom onClusterClick handler when creating the MarkerClusterer
- stop the default cluster double-click behavior and pan to the cluster position
- zoom in toward the cluster while capping the zoom level for repeated clicks

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de307bbfc88330b58cfeb252637604