### PR TITLE
Handle cluster clicks without assuming stop function

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -195,7 +195,22 @@ export default function Map({ objects, loading, language }: MapProps) {
           maxDistance: 40000
         }),
         onClusterClick: (event, cluster, mapInstance) => {
-          event.stop()
+          type ClusterClickEvent = google.maps.MapMouseEvent & {
+            stop?: () => void
+            domEvent?: {
+              stopPropagation?: () => void
+              preventDefault?: () => void
+            }
+          }
+
+          const clusterClickEvent = event as ClusterClickEvent
+
+          if (typeof clusterClickEvent.stop === 'function') {
+            clusterClickEvent.stop()
+          } else {
+            clusterClickEvent.domEvent?.stopPropagation?.()
+            clusterClickEvent.domEvent?.preventDefault?.()
+          }
 
           const map = mapRef.current ?? mapInstance
           const position = cluster?.position


### PR DESCRIPTION
## Summary
- guard cluster click events before calling the `stop` handler
- fall back to stopping propagation and default behavior through the DOM event when available

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68de33d4e21083309e18614f50d2b1cb