### PR TITLE
Fix cluster double-click zoom timing

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -266,13 +266,20 @@ export default function Map({ objects, loading, language }: MapProps) {
             if (clusterBounds && !clusterBounds.isEmpty()) {
               map.fitBounds(clusterBounds, { top: 40, bottom: 40, left: 40, right: 40 })
 
-              google.maps.event.addListenerOnce(map, 'idle', () => {
+              const scheduleZoomAdjustment = () => {
                 const currentZoom = map.getZoom() ?? 0
                 const targetZoom = Math.min(currentZoom + 1, maxZoom)
+
                 if (targetZoom > currentZoom) {
                   map.setZoom(targetZoom)
                 }
-              })
+              }
+
+              if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(scheduleZoomAdjustment)
+              } else {
+                setTimeout(scheduleZoomAdjustment, 0)
+              }
             }
 
             return


### PR DESCRIPTION
## Summary
- replace the idle listener used after fitting cluster bounds with a browser timing callback
- ensure the deferred zoom adjustment re-reads the current zoom level before applying a tighter zoom

## Testing
- not run (local environment requires interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68de3a22a7e08330a7c205e8d10e156a