### PR TITLE
Handle Google Maps cluster double click variants

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -201,7 +201,7 @@ export default function Map({ objects, loading, language }: MapProps) {
               stopPropagation?: () => void
               preventDefault?: () => void
               type?: string
-              detail?: { type?: string }
+              detail?: { type?: string } | number
             }
           }
 
@@ -222,9 +222,19 @@ export default function Map({ objects, loading, language }: MapProps) {
           }
 
           const domEventType =
-            clusterClickEvent.domEvent?.type ?? clusterClickEvent.domEvent?.detail?.type
+            clusterClickEvent.domEvent?.type ??
+            (typeof clusterClickEvent.domEvent?.detail === 'object'
+              ? clusterClickEvent.domEvent.detail?.type
+              : undefined)
 
-          if (domEventType === 'dblclick') {
+          const isDoubleClick =
+            domEventType === 'dblclick' ||
+            domEventType === 'gmp-dblclick' ||
+            (domEventType === 'gmp-click' &&
+              typeof clusterClickEvent.domEvent?.detail === 'number' &&
+              clusterClickEvent.domEvent.detail >= 2)
+
+          if (isDoubleClick) {
             const markers = (cluster as any)?.markers ?? []
             const maxZoom = 21
 


### PR DESCRIPTION
## Summary
- broaden the cluster click handler to recognize Google Maps double-click event variants
- support numeric detail payloads when determining double-clicks
- ensure zoom and fitBounds behavior executes only for double-click interactions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de3f0dd324833090e55bc86ae30ba8