### PR TITLE
Handle double-click detail objects in map cluster events

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -221,18 +221,22 @@ export default function Map({ objects, loading, language }: MapProps) {
             return
           }
 
-          const domEventType =
-            clusterClickEvent.domEvent?.type ??
-            (typeof clusterClickEvent.domEvent?.detail === 'object'
-              ? clusterClickEvent.domEvent.detail?.type
-              : undefined)
+          const domEvent = clusterClickEvent.domEvent
+          const domEventType = domEvent?.type
+          const detail = domEvent?.detail
+          const detailType =
+            typeof detail === 'object' && detail !== null && 'type' in detail
+              ? (detail as { type?: string }).type
+              : undefined
 
           const isDoubleClick =
             domEventType === 'dblclick' ||
             domEventType === 'gmp-dblclick' ||
+            detailType === 'dblclick' ||
+            detailType === 'gmp-dblclick' ||
             (domEventType === 'gmp-click' &&
-              typeof clusterClickEvent.domEvent?.detail === 'number' &&
-              clusterClickEvent.domEvent.detail >= 2)
+              typeof detail === 'number' &&
+              detail >= 2)
 
           if (isDoubleClick) {
             const markers = (cluster as any)?.markers ?? []


### PR DESCRIPTION
## Summary
- capture the cluster click DOM event and extract detail information
- treat object-based detail types as double clicks while retaining numeric fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de437766a883308678894f6bff72e4