### PR TITLE
Fix coordinate icon condition

### DIFF
--- a/components/admin/ObjectsTable.tsx
+++ b/components/admin/ObjectsTable.tsx
@@ -193,7 +193,7 @@ export default function ObjectsTable({ objects, total, page, pages, searchParams
                     </Typography>
                   </TableCell>
                   <TableCell align="center">
-                    {object.latitude && object.longitude ? (
+                    {object.latitude != null && object.longitude != null ? (
                       <Tooltip title={`${object.latitude}, ${object.longitude}`}>
                         <LocationOnIcon color="success" fontSize="small" />
                       </Tooltip>


### PR DESCRIPTION
## Summary
- ensure the coordinate icon still renders when zero-valued latitude/longitude are present by explicitly checking for nullish coordinates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de64e53f1c833097904d36bad8934d