### PR TITLE
Allow optional Map ID when loading Google Maps

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -53,13 +53,15 @@ export default function Map({ objects, loading, language }: MapProps) {
   const [mapError, setMapError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!apiKey || !mapId) return
+    if (!apiKey) return
 
     let isMounted = true
 
     setMapError(null)
 
-    loadGoogleMaps(language, mapId)
+    const normalizedMapId = mapId || undefined
+
+    loadGoogleMaps(language, normalizedMapId)
       .then(() => {
         if (!isMounted || !mapContainerRef.current) return
 
@@ -71,8 +73,10 @@ export default function Map({ objects, loading, language }: MapProps) {
         const mapOptions: google.maps.MapOptions = {
           ...DEFAULT_MAP_OPTIONS,
           center: KAZAKHSTAN_CENTER,
-          zoom: 5,
-          mapId
+          zoom: 5
+        }
+        if (normalizedMapId) {
+          mapOptions.mapId = normalizedMapId
         }
         mapRef.current = new google.maps.Map(mapContainerRef.current, mapOptions)
 
@@ -118,7 +122,7 @@ export default function Map({ objects, loading, language }: MapProps) {
       mapRef.current = null
       setMapReady(false)
     }
-  }, [language, apiKey])
+  }, [language, apiKey, mapId])
 
   useEffect(() => {
     if (!mapReady) return


### PR DESCRIPTION
## Summary
- allow the map component to initialize when only the Google Maps API key is provided
- normalize the mapId value so the loader receives undefined when absent and add the mapId option conditionally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de69e327108330b510034617f7a70c