### PR TITLE
Sync map filter search input with external updates

### DIFF
--- a/components/map/FilterPanel.tsx
+++ b/components/map/FilterPanel.tsx
@@ -182,6 +182,16 @@ export default function FilterPanel({
     setSuggestions([])
   }, [language])
 
+  useEffect(() => {
+    const currentSearch = filters.search || ''
+    setSearchInput(currentSearch)
+    latestQueryRef.current = currentSearch
+
+    if (!currentSearch) {
+      setSuggestions([])
+    }
+  }, [filters.search])
+
   const handleTypeToggle = (typeId: string) => {
     const newTypeIds = filters.typeIds.includes(typeId)
       ? filters.typeIds.filter(id => id !== typeId)


### PR DESCRIPTION
## Summary
- synchronize the search input state with external filter changes so UI reflects resets
- clear search suggestions when the search query becomes empty to avoid stale results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6af7b75c833092afdb1052fc0216