### PR TITLE
Add bottom spacing to map filter panel

### DIFF
--- a/components/map/FilterPanel.tsx
+++ b/components/map/FilterPanel.tsx
@@ -234,8 +234,8 @@ export default function FilterPanel({
 
   return (
     <>
-      <Paper 
-        className="filter-panel" 
+      <Paper
+        className="filter-panel"
         elevation={3}
         sx={{
           position: 'absolute',
@@ -243,8 +243,9 @@ export default function FilterPanel({
           left: 20,
           zIndex: 1000,
           width: { xs: 'calc(100% - 40px)', sm: 320 },
-          maxHeight: 'calc(100vh - 120px)',
-          overflow: 'auto'
+          maxHeight: 'calc(100vh - 100px)',
+          overflow: 'auto',
+          mb: '20px'
         }}
       >
         <Box sx={{ p: 2 }}>


### PR DESCRIPTION
## Summary
- add a bottom margin to the map filter panel container and adjust its max height to maintain spacing when constrained

## Testing
- npm run build *(fails: Prisma requires DATABASE_URL and API routes require dynamic server rendering support)*

------
https://chatgpt.com/codex/tasks/task_e_68de767dc428833093a2a43208bffaa6