### PR TITLE
Add pointer cursor and tooltip to cluster markers

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -27,9 +27,11 @@ const createClusterRenderer = () => {
           <text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="white" font-size="14" font-weight="bold">${count}</text>
         </svg>
       `
-      
+
       const div = document.createElement('div')
       div.innerHTML = svg
+      div.style.cursor = 'pointer'
+      div.title = 'Двойной клик для приближения'
 
       return new google.maps.marker.AdvancedMarkerElement({
         position,


### PR DESCRIPTION
## Summary
- add pointer cursor to custom cluster marker div
- add tooltip text instructing users to double click to zoom

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc6c759548330b652a9ed5dc5fc45