### PR TITLE
Adjust cluster double-click detection on map clusters

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -233,7 +233,7 @@ export default function Map({ objects, loading, language }: MapProps) {
 
           const now = Date.now()
           const timeSinceLastClick = now - lastClickTimeRef.current
-          const isDoubleClick = timeSinceLastClick < 300
+          const isDoubleClick = timeSinceLastClick < 300 && clickTimerRef.current !== null
           lastClickTimeRef.current = now
 
           if (isDoubleClick) {


### PR DESCRIPTION
## Summary
- require a pending single-click timer before treating cluster taps as double-clicks to ensure proper handling of rapid clicks

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfcbd5135c8330bb2e7284184beb42