### PR TITLE
Add tooltip metadata to Google Maps clusters

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -31,12 +31,13 @@ const createClusterRenderer = () => {
       const div = document.createElement('div')
       div.innerHTML = svg
       div.style.cursor = 'pointer'
-      div.title = 'Двойной клик для приближения'
 
       return new google.maps.marker.AdvancedMarkerElement({
         position,
         content: div,
-        zIndex: Number(google.maps.Marker.MAX_ZINDEX) + count
+        zIndex: Number(google.maps.Marker.MAX_ZINDEX) + count,
+        title: 'Двойной клик для приближения',
+        ariaLabel: 'Двойной клик для приближения'
       })
     }
   }


### PR DESCRIPTION
## Summary
- add a title and aria label to cluster AdvancedMarkerElement instances so Google Maps shows its default tooltip

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcf47dd34833089f626bf2fe1bfc1