### PR TITLE
Allow free map movement and pad Google Maps UI

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { loadGoogleMaps } from '@/hooks/useGoogleMaps'
 import { MarkerClusterer, GridAlgorithm } from '@googlemaps/markerclusterer'
-import { DEFAULT_MAP_OPTIONS, KAZAKHSTAN_BOUNDS, KAZAKHSTAN_CENTER } from '@/lib/constants'
+import { DEFAULT_MAP_OPTIONS, KAZAKHSTAN_BOUNDS, KAZAKHSTAN_CENTER, MAP_UI_PADDING } from '@/lib/constants'
 import { CircularProgress, Box, Typography } from '@mui/material'
 import MarkerInfo from './MarkerInfo'
 import { createRoot, Root } from 'react-dom/client'
@@ -80,6 +80,9 @@ export default function Map({ objects, loading, language }: MapProps) {
           mapOptions.mapId = normalizedMapId
         }
         mapRef.current = new google.maps.Map(mapContainerRef.current, mapOptions)
+        mapRef.current.setOptions({
+          padding: MAP_UI_PADDING
+        })
 
         const bounds = new google.maps.LatLngBounds(
           new google.maps.LatLng(KAZAKHSTAN_BOUNDS.south, KAZAKHSTAN_BOUNDS.west),

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -19,11 +19,14 @@ export const DEFAULT_MAP_OPTIONS: google.maps.MapOptions = {
   mapTypeControl: false,
   streetViewControl: false,
   fullscreenControl: true,
-  zoomControl: true,
-  restriction: {
-    latLngBounds: KAZAKHSTAN_BOUNDS,
-    strictBounds: false
-  }
+  zoomControl: true
+}
+
+export const MAP_UI_PADDING: google.maps.Padding = {
+  top: 96,
+  right: 24,
+  bottom: 24,
+  left: 24
 }
 
 // Настройки кластеризации


### PR DESCRIPTION
## Summary
- remove the Google Maps bounds restriction so users can freely pan the map
- add consistent padding to the map canvas to keep info windows clear of the sticky header

## Testing
- npm run lint *(fails: interactive configuration prompt in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e44859d7088330994a261c9dcc9760