### PR TITLE
Fix map padding options type error

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -93,15 +93,6 @@ export default function Map({ objects, loading, language }: MapProps) {
           mapOptions.mapId = normalizedMapId
         }
         mapRef.current = new google.maps.Map(mapContainerRef.current, mapOptions)
-        mapRef.current.setOptions({
-          padding: MAP_UI_PADDING
-        })
-
-        if ('setPadding' in mapRef.current && typeof mapRef.current.setPadding === 'function') {
-          mapRef.current.setPadding(MAP_UI_PADDING)
-        } else {
-          mapRef.current.set('padding', MAP_UI_PADDING)
-        }
 
         applyMapPadding(mapRef.current)
 


### PR DESCRIPTION
## Summary
- remove the invalid `padding` option passed directly to `google.maps.Map#setOptions`
- rely on the existing helper to apply padding in a type-safe way after map creation

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e44ff6d8548330a03b9ab5c9048ad7