### PR TITLE
Fix map cluster filtering and color dominance

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -103,10 +103,11 @@ export default function HomePage() {
           onLanguageChange={handleLanguageChange}
         />
         <div style={{ flex: 1, position: 'relative' }}>
-          <Map 
+          <Map
             objects={objects}
             loading={loading}
             language={language}
+            selectedTypeIds={filters.typeIds}
           />
           <FilterPanel
             filters={filters}


### PR DESCRIPTION
## Summary
- compute marker metadata for Google Maps markers and color clusters by the dominant selected infrastructure type with priority tie-breaking
- rebuild cluster data immediately when filters change by feeding selected type IDs into the map component

## Testing
- npm run lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e55f54c7988330aeb36c01c9e353a4