### PR TITLE
Clear map markers while loading new filter data

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -261,7 +261,7 @@ export default function AtlasMap({ objects, loading, language, selectedTypeIds }
 
   useEffect(() => {
     if (!mapReady) return
-    if (!mapRef.current || loading) return
+    if (!mapRef.current) return
     if (!(window as any).google || !(window as any).google.maps) {
       setMapError('Google Maps SDK not available')
       return
@@ -284,6 +284,8 @@ export default function AtlasMap({ objects, loading, language, selectedTypeIds }
       infoWindowRootRef.current.unmount()
       infoWindowRootRef.current = null
     }
+
+    if (loading) return
 
     const newMarkers: MarkerWithMeta[] = []
 


### PR DESCRIPTION
## Summary
- clear markers, clusters, and info windows even while data is loading so old objects disappear when filters change
- keep re-creating markers once new data arrives

## Testing
- npm run lint *(fails: command requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e5788d5f188330948bac345bc3ebd7