### PR TITLE
Fix clusterer cleanup to remove stale markers

### DIFF
--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -237,13 +237,13 @@ export default function AtlasMap({ objects, loading, language, selectedTypeIds }
 
     return () => {
       isMounted = false
-      clustererRef.current?.setMap(null)
       markersRef.current.forEach(marker => {
         MarkerUtils.setMap(marker, null)
       })
       markersRef.current = []
       if (clustererRef.current) {
         clustererRef.current.clearMarkers(true)
+        clustererRef.current.setMap(null)
         clustererRef.current = null
       }
       if (infoWindowRef.current) {
@@ -274,6 +274,7 @@ export default function AtlasMap({ objects, loading, language, selectedTypeIds }
       if (clustererRef.current?.getMap()) {
         clustererRef.current.clearMarkers(true)
       }
+      clustererRef.current.setMap(null)
       clustererRef.current = null
     }
 


### PR DESCRIPTION
## Summary
- ensure existing marker clusterers are fully detached from the map before recreation
- clear markers and detach the clusterer when the component unmounts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e58084d66083308a56153c95e6c8d9